### PR TITLE
x64.exe fix script and refactor

### DIFF
--- a/publish.bat
+++ b/publish.bat
@@ -1,16 +1,13 @@
 echo off
 
-dotnet publish .\src\CyberdropDownloader.Avalonia\ -p:PublishProfile=win-x64 -v quiet /p:DebugType=None
+dotnet publish .\src\CyberdropDownloader.Avalonia\ -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:PublishProfile=win-x64 -v quiet /p:DebugType=None
 echo win-x64 published
 
-dotnet publish .\src\CyberdropDownloader.Avalonia\ -p:PublishProfile=win-x86 -v quiet /p:DebugType=None
+dotnet publish .\src\CyberdropDownloader.Avalonia\ -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:PublishProfile=win-x86 -v quiet /p:DebugType=None
 echo win-x86 published
  
-dotnet publish .\src\CyberdropDownloader.Avalonia\ -p:PublishProfile=linux-x64 -v quiet /p:DebugType=None
+dotnet publish .\src\CyberdropDownloader.Avalonia\ -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:PublishProfile=linux-x64 -v quiet /p:DebugType=None
 echo linux-x64 published
  
-dotnet publish .\src\CyberdropDownloader.Avalonia\ -p:PublishProfile=osx-x64 -v quiet /p:DebugType=None
+dotnet publish .\src\CyberdropDownloader.Avalonia\ -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:PublishProfile=osx-x64 -v quiet /p:DebugType=None
 echo osx-x64 published
-
-dotnet publish -r win-x64 .\src\CyberdropDownloader.Avalonia\ -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:PublishProfile=win-x64 -v quiet -p:DebugType=None
-echo x64-client.exe published

--- a/publish.bat
+++ b/publish.bat
@@ -12,5 +12,5 @@ echo linux-x64 published
 dotnet publish .\src\CyberdropDownloader.Avalonia\ -p:PublishProfile=osx-x64 -v quiet /p:DebugType=None
 echo osx-x64 published
 
-publish -r win-x64 ./src/CyberdropDownloader.Avalonia /p:PublishSingleFile=true /p:IncludeNativeLibrariesForSelfExtract=true -p:PublishProfile=win-x64 -v quiet /p:DebugType=None
+dotnet publish -r win-x64 .\src\CyberdropDownloader.Avalonia\ -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:PublishProfile=win-x64 -v quiet -p:DebugType=None
 echo x64-client.exe published


### PR DESCRIPTION
This `dotnet publish .\src\CyberdropDownloader.Avalonia\ -p:PublishProfile=win-x64 -v quiet /p:DebugType=None` does not compiles `libHarfBuzzSharp.dll` and `libSkiaSharp.dll`.
![image](https://user-images.githubusercontent.com/24191952/132642879-fa6fc7a6-6a55-4eaa-a0cd-aee4e09d824b.png)


This command compiles all dll into a single `.exe` file.