### PR TITLE
Checks availability of all servers

### DIFF
--- a/src/CyberdropDownloader.Avalonia/ViewModels/MainWindowViewModel.cs
+++ b/src/CyberdropDownloader.Avalonia/ViewModels/MainWindowViewModel.cs
@@ -196,8 +196,28 @@ namespace CyberdropDownloader.Avalonia.ViewModels
                             }
                         }
 
-                        // Download album
-                        await _albumDownloader.DownloadAsync(_webScraper.Album, _destinationInput.Text, _cancellationTokenSource?.Token, 100).ConfigureAwait(false);
+                        try 
+                        {
+                            // Download album
+                            await _albumDownloader.DownloadAsync(_webScraper.Album, _destinationInput.Text, _cancellationTokenSource?.Token, 100).ConfigureAwait(false);
+                        }
+                        catch (Exception ex)
+                        {
+                            switch (ex)
+                            {
+                                case UriFormatException:
+                                    Log("Invalid URL format.");
+                                    break;
+                                
+                                case AllServersAreUnreachable:
+                                    Log("All Cyberdrop servers are unreachable at the time");
+                                    break;
+
+                                default:
+                                    Log($"Unknown webscraper error. Please report this to the github repository. {ex.Message}");
+                                    continue;
+                            } 
+                        }
                     }
 
                     // IF the total downloads are greater or equal to 1 then log the total downloads

--- a/src/CyberdropDownloader.Core/Exceptions/AllServersAreUnreachable.cs
+++ b/src/CyberdropDownloader.Core/Exceptions/AllServersAreUnreachable.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace CyberdropDownloader.Core.Exceptions
+{
+    public class AllServersAreUnreachable : Exception
+    {
+        public AllServersAreUnreachable()
+        {
+        }
+
+        public AllServersAreUnreachable(string message) : base(message)
+        {
+        }
+
+        public AllServersAreUnreachable(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        protected AllServersAreUnreachable(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Hello.
I've noticed that Cyberdrop have few data servers (like fs-01, fs-02 etc) and publish links to uploaded pictures on web pages only to one of them, but pictures themselves are actually presents on every other server. Also, from time to time a server from URL is unanavailable. I've fixed this issue with iteration through all known server names and calls to them untill working one is found.